### PR TITLE
Update to adhere to naming convention

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - run: npx @dappnode/dappnodesdk build --provider remote --skip_save
-      
+
   #e2e-test:
    # runs-on: gnosis
    # needs: build-test
@@ -26,7 +26,7 @@ jobs:
    # name: End to end tests
    # steps:
     #  - uses: actions/checkout@v3
-    #  - run: npx @dappnode/dappnodesdk@latest github-action test-end-to-end --errorLogsTimeout 120 --healthCheckUrl http://erigon-gnosis.dappnode:8545 --network gnosis
+    #  - run: npx @dappnode/dappnodesdk@latest github-action test-end-to-end --errorLogsTimeout 120 --healthCheckUrl http://gnosis-erigon.dappnode:8545 --network gnosis
 
   release:
     name: Release

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,5 +1,5 @@
 {
-  "name": "erigon-gnosis.dnp.dappnode.eth",
+  "name": "gnosis-erigon.dnp.dappnode.eth",
   "version": "0.1.0",
   "shortDescription": "Modular Ethereum client on the efficiency frontier, written in Go, for the Gnosis Chain network",
   "description": "Erigon is a next generation Ethereum client that introduces several new concepts:\n\n* A modular client design, enabling parallelized development of the client\n\n* New (`flat`) model of storing Ethereum state, allowing a lower disk footprint\n\n* Preprocessing of data outside of the storage engine, making database write operations faster by a magnitude\n\n* Staged synchronization technique, allowing very fast synchronization",
@@ -17,8 +17,8 @@
     "Voss <voss@visnovalabs.io> (https://github.com/alexpeterson91)"
   ],
   "links": {
-    "api": "http://erigon-gnosis.dappnode:8545",
-    "apiEngine": "http://erigon-gnosis.dappnode:8551",
+    "api": "http://gnosis-erigon.dappnode:8545",
+    "apiEngine": "http://gnosis-erigon.dappnode:8551",
     "homepage": "https://github.com/ledgerwatch/erigon"
   },
   "mainService": "erigon",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   erigon:
-    image: "erigon.erigon-gnosis.dnp.dappnode.eth:0.1.0"
+    image: "erigon.gnosis-erigon.dnp.dappnode.eth:0.1.0"
     build:
       context: .
       args:
@@ -10,7 +10,7 @@ services:
       - "31305:31305/tcp"
       - "31305:31305/udp"
     volumes:
-      - "data:/home/erigon-gnosis/.local/share"
+      - "data:/home/gnosis-erigon/.local/share"
     environment:
       P2P_PORT: 31305
       TORRENT_PORT: 43084

--- a/erigon/entrypoint.sh
+++ b/erigon/entrypoint.sh
@@ -35,7 +35,7 @@ PORT="${P2P_PORT:=30303}"
 TORRENT_PORT="${TORRENT_PORT:=43084}"
 PPROF_PORT="${PPROF_PORT:=6061}"
 
-DATADIR="/home/erigon-gnosis/.local/share"
+DATADIR="/home/gnosis-erigon/.local/share"
 
 ##########
 # Erigon #

--- a/getting-started.md
+++ b/getting-started.md
@@ -4,7 +4,7 @@ Welcome to the Merge Ready Erigon Gnosis Chain Execution Layer Client
 
 There are now two RPC APIs in Execution Clients:
 
-1. Querying API `http://erigon-gnosis.dappnode:8545`. Use this endpoint to query transactions on your node and connect to it with your web3 wallet.
-2. Engine API `http://erigon-gnosis.dappnode:8551`. Use this endpoint to connect your Beacon Chain (Consensus Layer) client.
+1. Querying API `http://gnosis-erigon.dappnode:8545`. Use this endpoint to query transactions on your node and connect to it with your web3 wallet.
+2. Engine API `http://gnosis-erigon.dappnode:8551`. Use this endpoint to connect your Beacon Chain (Consensus Layer) client.
 
 After the merge, if your Execution Client is not connected to a Consensus Layer client, you won't be able to keep it synced, nor use it to query the blockchain, nor will you be able to connect your wallet to it!

--- a/prometheus-targets.json
+++ b/prometheus-targets.json
@@ -1,12 +1,12 @@
 [
     {
         "labels": {
-            "package": "erigon-gnosis.dnp.dappnode.eth",
+            "package": "gnosis-erigon.dnp.dappnode.eth",
             "service": "erigon",
             "__metrics_path__": "/debug/metrics/prometheus"
         },
         "targets": [
-            "erigon.erigon-gnosis.dappnode:6060"
+            "erigon.gnosis-erigon.dappnode:6060"
         ]
     }
 ]


### PR DESCRIPTION
According to dappnode naming convention, naming for execution clients packages should follow the format: `network-client`