### PR TITLE
implement erigon3 changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 ARG UPSTREAM_VERSION
-
 FROM erigontech/erigon:${UPSTREAM_VERSION}
 
 USER root
 
+# Install curl
+RUN apt-get update && \
+    apt-get install -y curl && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY /security /security
+
+# Set up entrypoint script
 COPY /erigon/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod u+x /usr/local/bin/entrypoint.sh
 

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "shortDescription": "Modular Ethereum client on the efficiency frontier, written in Go, for the Gnosis Chain network",
   "description": "Erigon is a next generation Ethereum client that introduces several new concepts:\n\n* A modular client design, enabling parallelized development of the client\n\n* New (`flat`) model of storing Ethereum state, allowing a lower disk footprint\n\n* Preprocessing of data outside of the storage engine, making database write operations faster by a magnitude\n\n* Staged synchronization technique, allowing very fast synchronization",
-  "upstreamVersion": "v2.60.10",
+  "upstreamVersion": "v3.0.2",
   "upstreamRepo": "erigontech/erigon",
   "upstreamArg": "UPSTREAM_VERSION",
   "type": "service",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       args:
-        UPSTREAM_VERSION: v2.60.10
+        UPSTREAM_VERSION: v3.0.2
     ports:
       - 31305:31305/tcp
       - 31305:31305/udp

--- a/erigon/entrypoint.sh
+++ b/erigon/entrypoint.sh
@@ -43,6 +43,7 @@ DATADIR="/home/gnosis-erigon/.local/share"
 
 exec erigon --datadir=${DATADIR} \
     --chain=gnosis \
+    --externalcl \
     --http.addr=0.0.0.0 \
     --http.vhosts=* \
     --http.corsdomain=* \


### PR DESCRIPTION
- new flag needed for disabling embedded erigon's CL Caplin: `externalcl`
- bump upstream to 3.0.2
- add CURL 